### PR TITLE
Delete partition

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -356,13 +356,6 @@ impl Context {
             v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
         }
     }
-
-    pub fn apply_table(&self, table: &Table) -> Result<()> {
-        match unsafe { fdisk_sys::fdisk_apply_table(self.ptr, table.ptr) } {
-            0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
-        }
-    }
 }
 
 impl Drop for Context {

--- a/src/context.rs
+++ b/src/context.rs
@@ -356,6 +356,13 @@ impl Context {
             v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
         }
     }
+
+    pub fn apply_table(&self, table: &Table) -> Result<()> {
+        match unsafe { fdisk_sys::fdisk_apply_table(self.ptr, table.ptr) } {
+            0 => Ok(()),
+            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+        }
+    }
 }
 
 impl Drop for Context {

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -290,4 +290,14 @@ impl Context {
             v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
         }
     }
+
+    /// Delete the specified partition
+    /// # Arguments
+    /// * `patno` - partition number (0 is the first partition)
+    pub fn delete_partition(&self, no: usize) -> Result<()> {
+        match unsafe { fdisk_sys::fdisk_delete_partition(self.ptr, no) } {
+            0 => Ok(()),
+            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+        }
+    }
 }


### PR DESCRIPTION
Add a wrapper function to delete partition. This is necessary, since modifying the table struct does not affect the partition in the context struct. This mean, before this PR, there is no way to delete a partition, only the whole partition table.